### PR TITLE
Incompatible types "Address" and "<null>" for binary operator "!="

### DIFF
--- a/contracts/traits/tokens/jetton/JettonMaster.tact
+++ b/contracts/traits/tokens/jetton/JettonMaster.tact
@@ -69,7 +69,7 @@ trait JettonMaster {
 
     inline fun _burn_notification(ctx: Context, msg: JettonBurnNotification) {
         self.total_supply = (self.total_supply - msg.amount);
-        if (msg.response_destination != null) {
+        if (msg.response_destination.toString() != "") {
             send(SendParameters{
                     to: msg.response_destination,
                     value: 0,


### PR DESCRIPTION
Replaced msg.response_destination != null with msg.response_destination.toString() != ""

This new check properly handles the Address type and checks if it's initialized